### PR TITLE
fix: include request hostname in cache key to prevent cross-domain pollution

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ SIDEKICK_WP_MU_PLUGIN_ENABLED=false
 By default, Sidekick includes the following in cache keys:
 
 - **Query Parameters**: `p`, `page`, `paged`, `s`, `category`, `tag`, `author` (common WordPress parameters)
-- **Headers**: `Accept-Encoding` (to vary cache by compression support)
+- **Headers**: `Host` (automatically included to prevent cache poisoning/pollution), `Accept-Encoding` (to vary cache by compression support)
 - **Cookies**: `wordpress_logged_in_*`, `wordpress_sec_*`, `wp-settings-*` (WordPress session cookies, with wildcard support)
 
 ### Customizing Cache Keys

--- a/sidekick.go
+++ b/sidekick.go
@@ -1563,6 +1563,16 @@ func humanizeBytes(bytes int64) string {
 func (s *Sidekick) buildCacheKey(r *http.Request) string {
 	h := md5.New()
 
+	// Always include hostname to prevent cross-domain cache pollution.
+	// In multi-domain setups (e.g., WordPress Multisite with a catch-all
+	// Caddyfile block), different domains sharing the same path must have
+	// separate cache entries. Note: r.Host is used instead of
+	// r.Header.Get("Host") because Go's net/http promotes the Host header
+	// to r.Host and removes it from the header map.
+	if r.Host != "" {
+		h.Write([]byte(r.Host))
+	}
+
 	// Always include path
 	h.Write([]byte(r.URL.Path))
 
@@ -1581,9 +1591,18 @@ func (s *Sidekick) buildCacheKey(r *http.Request) string {
 		}
 	}
 
-	// Include configured headers
+	// Include configured headers.
+	// Special case: Go's net/http promotes the Host header to r.Host and
+	// removes it from r.Header, so r.Header.Get("Host") returns "".
+	// Fall back to r.Host when the header name is "Host".
 	for _, hdr := range s.CacheKeyHeaders {
-		if val := r.Header.Get(hdr); val != "" {
+		var val string
+		if strings.EqualFold(hdr, "Host") {
+			val = r.Host
+		} else {
+			val = r.Header.Get(hdr)
+		}
+		if val != "" {
 			h.Write([]byte(hdr + ":" + val))
 		}
 	}

--- a/sidekick_test.go
+++ b/sidekick_test.go
@@ -319,10 +319,46 @@ func TestBuildCacheKey_WildcardCookieValues(t *testing.T) {
 
 	// Verify the cookie value is actually used in the hash
 	h := md5.New()
+	h.Write([]byte(""))    // empty host from httptest
 	h.Write([]byte("/test"))
 	h.Write([]byte("test_cookie=value1"))
 	expectedKey1 := fmt.Sprintf("%x", h.Sum(nil))
 	assert.Equal(t, expectedKey1, key1, "Cache key should include cookie name and value")
+}
+
+// TestBuildCacheKey_HostIsolation tests that different hostnames produce different cache keys
+func TestBuildCacheKey_HostIsolation(t *testing.T) {
+	s := &Sidekick{
+		logger: zap.NewNop(),
+	}
+
+	req1 := httptest.NewRequest("GET", "https://example.com/", nil)
+	req2 := httptest.NewRequest("GET", "https://other.com/", nil)
+	req3 := httptest.NewRequest("GET", "https://example.com/", nil)
+
+	key1 := s.buildCacheKey(req1)
+	key2 := s.buildCacheKey(req2)
+	key3 := s.buildCacheKey(req3)
+
+	assert.NotEqual(t, key1, key2, "Different hostnames should produce different cache keys")
+	assert.Equal(t, key1, key3, "Same hostname and path should produce the same cache key")
+}
+
+// TestBuildCacheKey_HostHeader tests that cache_key_headers with "Host" works
+// despite Go promoting the Host header to r.Host
+func TestBuildCacheKey_HostHeader(t *testing.T) {
+	s := &Sidekick{
+		CacheKeyHeaders: []string{"Host"},
+		logger:          zap.NewNop(),
+	}
+
+	req1 := httptest.NewRequest("GET", "https://example.com/test", nil)
+	req2 := httptest.NewRequest("GET", "https://other.com/test", nil)
+
+	key1 := s.buildCacheKey(req1)
+	key2 := s.buildCacheKey(req2)
+
+	assert.NotEqual(t, key1, key2, "cache_key_headers with Host should differentiate domains")
 }
 
 // TestShouldBypass_PrefixMatching tests that nocache paths use prefix matching


### PR DESCRIPTION
## Summary

- Always include `r.Host` in the cache key hash so different domains get separate cache entries
- Handle `Host` in `cache_key_headers` by reading `r.Host` instead of `r.Header.Get("Host")`, since Go promotes the Host header out of the header map
- Add tests for host isolation and Host header cache key behavior

Closes #2

## Problem

`buildCacheKey()` only used `r.URL.Path`, query params, headers, and cookies. The request hostname was never included, so in multi-domain setups (e.g., WordPress Multisite with a catch-all `https://` Caddyfile block), all domains sharing the same path served identical cached content.

Adding `Host` to `cache_key_headers` didn't help because Go's `net/http` promotes the `Host` header to `r.Host` and removes it from `r.Header` — so `r.Header.Get("Host")` always returns `""`.

## Changes

**`sidekick.go`**:
- `buildCacheKey()`: always write `r.Host` into the hash before the path
- Header loop: when the configured header name is `Host` (case-insensitive), read from `r.Host` instead of `r.Header.Get()`

**`sidekick_test.go`**:
- `TestBuildCacheKey_HostIsolation`: different hosts produce different keys, same host produces same key
- `TestBuildCacheKey_HostHeader`: `cache_key_headers` with `Host` correctly differentiates domains
- Updated existing `TestBuildCacheKey_WildcardCookieValues` expected hash to account for the empty host from `httptest`

## Compatibility

This is backward-compatible. Single-domain setups will have the same host in every key (no behavior change). Multi-domain setups get correct cache isolation. Existing cache entries will be invalidated on upgrade (different hash), which is the desired behavior.